### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pygbag.yml
+++ b/.github/workflows/pygbag.yml
@@ -7,6 +7,8 @@ jobs:
   build-pygbag:
     name: Build for Emscripten pygbag runtime
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Potential fix for [https://github.com/BruhNotOG/ProjectBeatsRemix/security/code-scanning/1](https://github.com/BruhNotOG/ProjectBeatsRemix/security/code-scanning/1)

In general, the fix is to explicitly declare a `permissions:` block in the workflow (or at the job level) that grants only the minimal rights required. For a build-and-deploy-to-GitHub-Pages job, this typically means giving `contents: read` to allow checkout, plus the minimal write scope needed by the deploy action (usually `contents: write` to push to `gh-pages`), while leaving all other scopes at their implicit default of `none`.

The best fix here is to add a `permissions:` section under the `build-pygbag` job in `.github/workflows/pygbag.yml`. This keeps the change localized to this job and avoids affecting any other workflows. Concretely, right after `runs-on: ubuntu-latest` we add:

```yaml
    permissions:
      contents: write
```

This is the narrowest, clearly-correct permission we can infer from the existing steps: `actions/checkout` needs `contents: read` (implied by `write`), and the GitHub Pages deploy action needs to push to the `gh-pages` branch (`contents: write`). No new imports, methods, or external definitions are required since this is purely a YAML configuration change within the workflow file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
